### PR TITLE
Disable Windows DNS registration

### DIFF
--- a/internal/winipcfg/netsh.go
+++ b/internal/winipcfg/netsh.go
@@ -51,10 +51,11 @@ func runNetsh(cmds []string) error {
 }
 
 const (
-	netshCmdTemplateFlush4 = "interface ipv4 set dnsservers name=%d source=static address=none validate=no register=both"
-	netshCmdTemplateFlush6 = "interface ipv6 set dnsservers name=%d source=static address=none validate=no register=both"
-	netshCmdTemplateAdd4   = "interface ipv4 add dnsservers name=%d address=%s validate=no"
-	netshCmdTemplateAdd6   = "interface ipv6 add dnsservers name=%d address=%s validate=no"
+	netshCmdTemplateFlush4              = "interface ipv4 set dnsservers name=%d source=static address=none validate=no"
+	netshCmdTemplateFlush6              = "interface ipv6 set dnsservers name=%d source=static address=none validate=no"
+	netshCmdTemplateAdd4                = "interface ipv4 add dnsservers name=%d address=%s validate=no"
+	netshCmdTemplateAdd6                = "interface ipv6 add dnsservers name=%d address=%s validate=no"
+	netshCmdTemplateDisableRegistration = "interface ipv6 set dnsservers name=%d register=none"
 )
 
 func (luid LUID) fallbackSetDNSForFamily(family AddressFamily, dnses []netip.Addr) error {
@@ -105,4 +106,14 @@ func (luid LUID) fallbackSetDNSDomain(domain string) error {
 	err = key.SetStringValue("Domain", domain)
 	key.Close()
 	return err
+}
+
+func (luid LUID) fallbackDisableDNSRegistration() error {
+	// the DNS registration setting is shared for both IPv4 and IPv6
+	ipif, err := luid.IPInterface(windows.AF_INET)
+	if err != nil {
+		return err
+	}
+	cmd := fmt.Sprintf(netshCmdTemplateDisableRegistration, ipif.InterfaceIndex)
+	return runNetsh([]string{cmd})
 }

--- a/tun_windows.go
+++ b/tun_windows.go
@@ -88,6 +88,9 @@ func (t *NativeTun) configure() error {
 			return E.Cause(err, "set ipv6 dns")
 		}
 	}
+	if len(t.options.Inet4Address) > 0 || len(t.options.Inet6Address) > 0 {
+		_ = luid.DisableDNSRegistration()
+	}
 	if t.options.AutoRoute {
 		if len(t.options.Inet4Address) > 0 {
 			if len(t.options.Inet4RouteAddress) > 0 {


### PR DESCRIPTION
It doesn't make sense to save TUN addresses elsewhere.