### PR TITLE
replace exec.Start() with exec.Run() to avoid zombie processes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/go-ole/go-ole v1.3.0
-	github.com/sagernet/gvisor v0.0.0-20240315080113-799fb6b6d311
+	github.com/sagernet/gvisor v0.0.0-20240428053021-e691de28565f
 	github.com/sagernet/netlink v0.0.0-20220905062125-8043b4a9aa97
 	github.com/sagernet/sing v0.3.8
 	go4.org/netipx v0.0.0-20231129151722-fdeea329fbba

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/go-ole/go-ole v1.3.0
-	github.com/sagernet/gvisor v0.0.0-20231209105102-8d27a30e436e
+	github.com/sagernet/gvisor v0.0.0-20240214044702-a3d61928a32f
 	github.com/sagernet/netlink v0.0.0-20220905062125-8043b4a9aa97
 	github.com/sagernet/sing v0.3.8
 	go4.org/netipx v0.0.0-20231129151722-fdeea329fbba

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/go-ole/go-ole v1.3.0
-	github.com/sagernet/gvisor v0.0.0-20240214044702-a3d61928a32f
+	github.com/sagernet/gvisor v0.0.0-20240315080113-799fb6b6d311
 	github.com/sagernet/netlink v0.0.0-20220905062125-8043b4a9aa97
 	github.com/sagernet/sing v0.3.8
 	go4.org/netipx v0.0.0-20231129151722-fdeea329fbba

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/go-ole/go-ole v1.3.0/go.mod h1:5LS6F96DhAwUc7C+1HLexzMXY1xGRSryjyPPKW
 github.com/google/btree v1.1.2 h1:xf4v41cLI2Z6FxbKm+8Bu+m8ifhj15JuZ9sa0jZCMUU=
 github.com/google/btree v1.1.2/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
-github.com/sagernet/gvisor v0.0.0-20240214044702-a3d61928a32f h1:7hj/CcCkUiC6gfhX4D+QNyodmhfurW2L2Q4qzJ1bPnI=
-github.com/sagernet/gvisor v0.0.0-20240214044702-a3d61928a32f/go.mod h1:bLmnT/4M4+yKB6F7JtRsbUr+YJ64yXwFIygjyYDFQzQ=
+github.com/sagernet/gvisor v0.0.0-20240315080113-799fb6b6d311 h1:eUQ6kJZXK77xYZeeNrBb/7JMv0S0Wkk7EpmKUb3fsfc=
+github.com/sagernet/gvisor v0.0.0-20240315080113-799fb6b6d311/go.mod h1:mDrXZSv401qiaFiiIUC59Zp4VG5f4nqXFqDmp5o3hYI=
 github.com/sagernet/netlink v0.0.0-20220905062125-8043b4a9aa97 h1:iL5gZI3uFp0X6EslacyapiRz7LLSJyr4RajF/BhMVyE=
 github.com/sagernet/netlink v0.0.0-20220905062125-8043b4a9aa97/go.mod h1:xLnfdiJbSp8rNqYEdIW/6eDO4mVoogml14Bh2hSiFpM=
 github.com/sagernet/sing v0.3.8 h1:gm4JKalPhydMYX2zFOTnnd4TXtM/16WFRqSjMepYQQk=

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/go-ole/go-ole v1.3.0/go.mod h1:5LS6F96DhAwUc7C+1HLexzMXY1xGRSryjyPPKW
 github.com/google/btree v1.1.2 h1:xf4v41cLI2Z6FxbKm+8Bu+m8ifhj15JuZ9sa0jZCMUU=
 github.com/google/btree v1.1.2/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
-github.com/sagernet/gvisor v0.0.0-20231209105102-8d27a30e436e h1:DOkjByVeAR56dkszjnMZke4wr7yM/1xHaJF3G9olkEE=
-github.com/sagernet/gvisor v0.0.0-20231209105102-8d27a30e436e/go.mod h1:fLxq/gtp0qzkaEwywlRRiGmjOK5ES/xUzyIKIFP2Asw=
+github.com/sagernet/gvisor v0.0.0-20240214044702-a3d61928a32f h1:7hj/CcCkUiC6gfhX4D+QNyodmhfurW2L2Q4qzJ1bPnI=
+github.com/sagernet/gvisor v0.0.0-20240214044702-a3d61928a32f/go.mod h1:bLmnT/4M4+yKB6F7JtRsbUr+YJ64yXwFIygjyYDFQzQ=
 github.com/sagernet/netlink v0.0.0-20220905062125-8043b4a9aa97 h1:iL5gZI3uFp0X6EslacyapiRz7LLSJyr4RajF/BhMVyE=
 github.com/sagernet/netlink v0.0.0-20220905062125-8043b4a9aa97/go.mod h1:xLnfdiJbSp8rNqYEdIW/6eDO4mVoogml14Bh2hSiFpM=
 github.com/sagernet/sing v0.3.8 h1:gm4JKalPhydMYX2zFOTnnd4TXtM/16WFRqSjMepYQQk=

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/go-ole/go-ole v1.3.0/go.mod h1:5LS6F96DhAwUc7C+1HLexzMXY1xGRSryjyPPKW
 github.com/google/btree v1.1.2 h1:xf4v41cLI2Z6FxbKm+8Bu+m8ifhj15JuZ9sa0jZCMUU=
 github.com/google/btree v1.1.2/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
-github.com/sagernet/gvisor v0.0.0-20240315080113-799fb6b6d311 h1:eUQ6kJZXK77xYZeeNrBb/7JMv0S0Wkk7EpmKUb3fsfc=
-github.com/sagernet/gvisor v0.0.0-20240315080113-799fb6b6d311/go.mod h1:mDrXZSv401qiaFiiIUC59Zp4VG5f4nqXFqDmp5o3hYI=
+github.com/sagernet/gvisor v0.0.0-20240428053021-e691de28565f h1:NkhuupzH5ch7b/Y/6ZHJWrnNLoiNnSJaow6DPb8VW2I=
+github.com/sagernet/gvisor v0.0.0-20240428053021-e691de28565f/go.mod h1:KXmw+ouSJNOsuRpg4wgwwCQuunrGz4yoAqQjsLjc6N0=
 github.com/sagernet/netlink v0.0.0-20220905062125-8043b4a9aa97 h1:iL5gZI3uFp0X6EslacyapiRz7LLSJyr4RajF/BhMVyE=
 github.com/sagernet/netlink v0.0.0-20220905062125-8043b4a9aa97/go.mod h1:xLnfdiJbSp8rNqYEdIW/6eDO4mVoogml14Bh2hSiFpM=
 github.com/sagernet/sing v0.3.8 h1:gm4JKalPhydMYX2zFOTnnd4TXtM/16WFRqSjMepYQQk=

--- a/stack_gvisor.go
+++ b/stack_gvisor.go
@@ -122,7 +122,7 @@ func (t *GVisor) Start() error {
 			if err != nil {
 				return
 			}
-			udpConn := gonet.NewUDPConn(ipStack, &wq, endpoint)
+			udpConn := gonet.NewUDPConn(&wq, endpoint)
 			lAddr := udpConn.RemoteAddr()
 			rAddr := udpConn.LocalAddr()
 			if lAddr == nil || rAddr == nil {

--- a/stack_gvisor_filter.go
+++ b/stack_gvisor_filter.go
@@ -32,7 +32,7 @@ type networkDispatcherFilter struct {
 	writer           N.VectorisedWriter
 }
 
-func (w *networkDispatcherFilter) DeliverNetworkPacket(protocol tcpip.NetworkProtocolNumber, pkt stack.PacketBufferPtr) {
+func (w *networkDispatcherFilter) DeliverNetworkPacket(protocol tcpip.NetworkProtocolNumber, pkt *stack.PacketBuffer) {
 	var network header.Network
 	if protocol == header.IPv4ProtocolNumber {
 		if headerPackets, loaded := pkt.Data().PullUp(header.IPv4MinimumSize); loaded {

--- a/stack_gvisor_udp.go
+++ b/stack_gvisor_udp.go
@@ -42,7 +42,7 @@ func NewUDPForwarder(ctx context.Context, stack *stack.Stack, handler Handler, u
 	}
 }
 
-func (f *UDPForwarder) HandlePacket(id stack.TransportEndpointID, pkt stack.PacketBufferPtr) bool {
+func (f *UDPForwarder) HandlePacket(id stack.TransportEndpointID, pkt *stack.PacketBuffer) bool {
 	var upstreamMetadata M.Metadata
 	upstreamMetadata.Source = M.SocksaddrFrom(AddrFromAddress(id.RemoteAddress), id.RemotePort)
 	upstreamMetadata.Destination = M.SocksaddrFrom(AddrFromAddress(id.LocalAddress), id.LocalPort)
@@ -174,7 +174,7 @@ func (c *gUDPConn) Close() error {
 	return c.UDPConn.Close()
 }
 
-func gWriteUnreachable(gStack *stack.Stack, packet stack.PacketBufferPtr, err error) (retErr error) {
+func gWriteUnreachable(gStack *stack.Stack, packet *stack.PacketBuffer, err error) (retErr error) {
 	if errors.Is(err, syscall.ENETUNREACH) {
 		if packet.NetworkProtocolNumber == header.IPv4ProtocolNumber {
 			return gWriteUnreachable4(gStack, packet, stack.RejectIPv4WithICMPNetUnreachable)
@@ -197,7 +197,7 @@ func gWriteUnreachable(gStack *stack.Stack, packet stack.PacketBufferPtr, err er
 	return nil
 }
 
-func gWriteUnreachable4(gStack *stack.Stack, packet stack.PacketBufferPtr, icmpCode stack.RejectIPv4WithICMPType) error {
+func gWriteUnreachable4(gStack *stack.Stack, packet *stack.PacketBuffer, icmpCode stack.RejectIPv4WithICMPType) error {
 	err := gStack.NetworkProtocolInstance(header.IPv4ProtocolNumber).(stack.RejectIPv4WithHandler).SendRejectionError(packet, icmpCode, true)
 	if err != nil {
 		return wrapStackError(err)
@@ -205,7 +205,7 @@ func gWriteUnreachable4(gStack *stack.Stack, packet stack.PacketBufferPtr, icmpC
 	return nil
 }
 
-func gWriteUnreachable6(gStack *stack.Stack, packet stack.PacketBufferPtr, icmpCode stack.RejectIPv6WithICMPType) error {
+func gWriteUnreachable6(gStack *stack.Stack, packet *stack.PacketBuffer, icmpCode stack.RejectIPv6WithICMPType) error {
 	err := gStack.NetworkProtocolInstance(header.IPv6ProtocolNumber).(stack.RejectIPv6WithHandler).SendRejectionError(packet, icmpCode, true)
 	if err != nil {
 		return wrapStackError(err)

--- a/stack_mixed.go
+++ b/stack_mixed.go
@@ -56,7 +56,7 @@ func (m *Mixed) Start() error {
 			if err != nil {
 				return
 			}
-			udpConn := gonet.NewUDPConn(ipStack, &wq, endpoint)
+			udpConn := gonet.NewUDPConn(&wq, endpoint)
 			lAddr := udpConn.RemoteAddr()
 			rAddr := udpConn.LocalAddr()
 			if lAddr == nil || rAddr == nil {

--- a/tun_darwin_gvisor.go
+++ b/tun_darwin_gvisor.go
@@ -102,10 +102,10 @@ func (e *DarwinEndpoint) ARPHardwareType() header.ARPHardwareType {
 	return header.ARPHardwareNone
 }
 
-func (e *DarwinEndpoint) AddHeader(buffer stack.PacketBufferPtr) {
+func (e *DarwinEndpoint) AddHeader(buffer *stack.PacketBuffer) {
 }
 
-func (e *DarwinEndpoint) ParseHeader(ptr stack.PacketBufferPtr) bool {
+func (e *DarwinEndpoint) ParseHeader(ptr *stack.PacketBuffer) bool {
 	return true
 }
 

--- a/tun_linux.go
+++ b/tun_linux.go
@@ -820,9 +820,9 @@ func (t *NativeTun) setSearchDomainForSystemdResolved() {
 	if len(t.options.Inet6Address) > 0 {
 		dnsServer = append(dnsServer, t.options.Inet6Address[0].Addr().Next())
 	}
-	shell.Exec(ctlPath, "domain", t.options.Name, "~.").Start()
+	shell.Exec(ctlPath, "domain", t.options.Name, "~.").Run()
 	if t.options.AutoRoute {
-		shell.Exec(ctlPath, "default-route", t.options.Name, "true").Start()
-		shell.Exec(ctlPath, append([]string{"dns", t.options.Name}, common.Map(dnsServer, netip.Addr.String)...)...).Start()
+		shell.Exec(ctlPath, "default-route", t.options.Name, "true").Run()
+		shell.Exec(ctlPath, append([]string{"dns", t.options.Name}, common.Map(dnsServer, netip.Addr.String)...)...).Run()
 	}
 }

--- a/tun_windows_gvisor.go
+++ b/tun_windows_gvisor.go
@@ -99,10 +99,10 @@ func (e *WintunEndpoint) ARPHardwareType() header.ARPHardwareType {
 	return header.ARPHardwareNone
 }
 
-func (e *WintunEndpoint) AddHeader(buffer stack.PacketBufferPtr) {
+func (e *WintunEndpoint) AddHeader(buffer *stack.PacketBuffer) {
 }
 
-func (e *WintunEndpoint) ParseHeader(ptr stack.PacketBufferPtr) bool {
+func (e *WintunEndpoint) ParseHeader(ptr *stack.PacketBuffer) bool {
 	return true
 }
 


### PR DESCRIPTION
According to https://pkg.go.dev/os/exec#Cmd.Start, `After a successful call to Start the Wait method must be called in order to release associated system resources.`

Or we just use Run().