### PR TITLE
remove dns if no address was set

### DIFF
--- a/tun_windows.go
+++ b/tun_windows.go
@@ -84,6 +84,12 @@ func (t *NativeTun) configure() error {
 				}
 			}
 		}
+	} else {
+		// If no IPv4 address is set, remove any existing IPv4 DNS servers
+		err := luid.SetDNS(winipcfg.AddressFamily(windows.AF_INET), nil, nil)
+		if err != nil {
+			return E.Cause(err, "remove ipv4 dns")
+		}
 	}
 	if len(t.options.Inet6Address) > 0 {
 		err := luid.SetIPAddressesForFamily(winipcfg.AddressFamily(windows.AF_INET6), t.options.Inet6Address)
@@ -101,6 +107,12 @@ func (t *NativeTun) configure() error {
 					return E.Cause(err, "set ipv6 dns")
 				}
 			}
+		}
+	} else {
+		// If no IPv6 address is set, remove any existing IPv6 DNS servers
+		err := luid.SetDNS(winipcfg.AddressFamily(windows.AF_INET6), nil, nil)
+		if err != nil {
+			return E.Cause(err, "remove ipv6 dns")
 		}
 	}
 	if len(t.options.Inet4Address) > 0 || len(t.options.Inet6Address) > 0 {


### PR DESCRIPTION
The interface will have dns server by default, can be checked by `Get-DnsClientServerAddress`
