### PR TITLE
make windows system stack create private interface

### DIFF
--- a/stack_system_windows.go
+++ b/stack_system_windows.go
@@ -20,6 +20,7 @@ func fixWindowsFirewall() error {
 		ApplicationName: absPath,
 		Enabled:         true,
 		Protocol:        winfw.NET_FW_IP_PROTOCOL_TCP,
+		Profiles:        winfw.NET_FW_PROFILE2_PRIVATE,
 		Direction:       winfw.NET_FW_RULE_DIR_IN,
 		Action:          winfw.NET_FW_ACTION_ALLOW,
 	}


### PR DESCRIPTION
Currently when using system stack, sing-tun creates a public network interface, and when using gVisor, it created a private one. This PR makes system stack create a private interface as well, making the firewall less restrictive and thus making the Tun interface more compatible.