### PR TITLE
fix typo of 'Android' in ErrNetlinkBanned error message

### DIFF
--- a/monitor_linux.go
+++ b/monitor_linux.go
@@ -27,7 +27,7 @@ type networkUpdateMonitor struct {
 var ErrNetlinkBanned = E.New(
 	"netlink socket in Android is banned by Google, " +
 		"use the root or system (ADB) user to run sing-box, " +
-		"or switch to the sing-box Adnroid graphical interface client",
+		"or switch to the sing-box Android graphical interface client",
 )
 
 func NewNetworkUpdateMonitor(logger logger.Logger) (NetworkUpdateMonitor, error) {


### PR DESCRIPTION
This PR fixes a typo in the error message of ErrNetlinkBanned