### PR TITLE
fix Windows firewall rules and allow to disable firewall manipulation

### DIFF
--- a/stack_system_windows.go
+++ b/stack_system_windows.go
@@ -15,15 +15,25 @@ func fixWindowsFirewall() error {
 	if err != nil {
 		return err
 	}
-	rule := winfw.FWRule{
+	_, err = winfw.FirewallRuleAddAdvanced(winfw.FWRule{
 		Name:            "sing-tun (" + absPath + ")",
 		ApplicationName: absPath,
 		Enabled:         true,
 		Protocol:        winfw.NET_FW_IP_PROTOCOL_TCP,
 		Direction:       winfw.NET_FW_RULE_DIR_IN,
 		Action:          winfw.NET_FW_ACTION_ALLOW,
+	})
+	if err != nil {
+		return err
 	}
-	_, err = winfw.FirewallRuleAddAdvanced(rule)
+	_, err = winfw.FirewallRuleAddAdvanced(winfw.FWRule{
+		Name:            "sing-tun UDP (" + absPath + ")",
+		ApplicationName: absPath,
+		Enabled:         true,
+		Protocol:        winfw.NET_FW_IP_PROTOCOL_UDP,
+		Direction:       winfw.NET_FW_RULE_DIR_IN,
+		Action:          winfw.NET_FW_ACTION_ALLOW,
+	})
 	return err
 }
 

--- a/tun.go
+++ b/tun.go
@@ -87,7 +87,8 @@ type Options struct {
 	_TXChecksumOffload bool
 
 	// For library usages.
-	EXP_DisableDNSHijack bool
+	EXP_DisableDNSHijack   bool
+	EXP_DisableFirewallFix bool
 }
 
 func (o *Options) Inet4GatewayAddr() netip.Addr {


### PR DESCRIPTION
- #12 introduced a TCP-only firewall rule to make system stack work for newbies. Manipulating firewall is not a good bahavior, so an option to disable this should be introduced.
- In MetaCubeX/mihomo#1875, someone claims that the TCP-only firewall rule causes "NAT type degradation" and adding a UDP firewall rule can fix this. Although a user can add corresponding UDP rule manually, no firewall pop-up is considered a bug in that issue. 
- I don't think one can achieve "endpoint independent" NAT filtering bahavior with a firewall blocking most of UDP ports, so I suspect it is a false positive result of "NatTypeTester" (known to have false positive results with continuous testing) rather than a real bug. Issue reporter is unwilling to further investigate so this change needs someone with local open NAT environment to confirm.
