### PR TITLE
auto-redirect: Fix `inet6_local_address_set`

### DIFF
--- a/redirect_nftables_rules.go
+++ b/redirect_nftables_rules.go
@@ -105,7 +105,7 @@ func (r *autoRedirect) nftablesCreateLocalAddressSets(
 		}
 		localAddresses6 = common.Filter(localAddresses6, func(it netip.Prefix) bool {
 			address := it.Addr()
-			return address.IsLoopback() || address.IsGlobalUnicast() && !address.IsPrivate()
+			return address.IsLoopback() || address.IsGlobalUnicast() && address.IsPrivate()
 		})
 		if len(lastAddresses) == 0 || update {
 			_, err := nftablesCreateIPSet(nft, table, 6, "inet6_local_address_set", nftables.TableFamilyIPv6, nil, localAddresses6, false, update)


### PR DESCRIPTION
The `inet6_local_address_set` should contain the tun IPv6 address instead of the regular IPv6 address as follows.
```console
$ sudo nft list set inet sing-box inet6_local_address_set
table inet sing-box {
        set inet6_local_address_set {
                type ipv6_addr
                flags interval
                elements = { ::1,
                             2400:aaaa:aaaa:aaa::/64 }
        }
}
```