### PR TITLE
feat: add InterfaceMetric and RouteMetric fields

### DIFF
--- a/tun.go
+++ b/tun.go
@@ -74,6 +74,8 @@ type Options struct {
 	Inet6Address                          []netip.Prefix
 	MTU                                   uint32
 	GSO                                   bool
+	InterfaceMetric                       uint32
+	RouteMetric                           uint32
 	AutoRoute                             bool
 	InterfaceScope                        bool
 	Inet4Gateway                          netip.Addr

--- a/tun_linux.go
+++ b/tun_linux.go
@@ -520,12 +520,16 @@ func (t *NativeTun) routes(tunLink netlink.Link) ([]netlink.Route, error) {
 		} else if it.Addr().Is6() && !gateway6.IsUnspecified() {
 			gateway = gateway6.AsSlice()
 		}
-		return netlink.Route{
+		route := netlink.Route{
 			Dst:       prefixToIPNet(it),
 			Gw:        gateway,
 			LinkIndex: tunLink.Attrs().Index,
 			Table:     t.options.IPRoute2TableIndex,
 		}
+		if t.options.RouteMetric > 0 {
+			route.Priority = int(t.options.RouteMetric)
+		}
+		return route
 	}), nil
 }
 


### PR DESCRIPTION
Resolves #62

This PR adds configurable interface and route metrics to allow users to control routing priorities across different devices with the same configuration file.

### Changes:
- Add `InterfaceMetric` field for TUN interface priority (Windows only)
- Add `RouteMetric` field for route priority (Windows and Linux)

### Backward Compatibility:
Both fields default to 0 (use existing behavior), maintaining full backward compatibility.