### PR TITLE
fix: omit nftables interval end when range hits max address

### DIFF
--- a/redirect_nftables_exprs.go
+++ b/redirect_nftables_exprs.go
@@ -149,17 +149,16 @@ func nftablesCreateIPSet(
 		if (family == nftables.TableFamilyIPv4) != rr.From().Is4() {
 			continue
 		}
-		endAddr := rr.To().Next()
-		if !endAddr.IsValid() {
-			endAddr = rr.From()
-		}
 		setElements = append(setElements, nftables.SetElement{
 			Key: rr.From().AsSlice(),
 		})
-		setElements = append(setElements, nftables.SetElement{
-			Key:         endAddr.AsSlice(),
-			IntervalEnd: true,
-		})
+		endAddr := rr.To().Next()
+		if endAddr.IsValid() {
+			setElements = append(setElements, nftables.SetElement{
+				Key:         endAddr.AsSlice(),
+				IntervalEnd: true,
+			})
+		}
 	}
 	if appendDefault && len(setElements) == 0 {
 		if family == nftables.TableFamilyIPv4 {


### PR DESCRIPTION
## Summary
- When building nftables interval sets, ranges whose upper bound is the address-family maximum (`255.255.255.255` / `ffff:...:ffff`) made `To().Next()` invalid.
- The old fallback set the interval end equal to the start, so nftables rejected the duplicate key with EEXIST (`file exists`).
- Omit the end element in that case so the half-open interval extends through the max address (same convention as other nftables consumers).

## Test plan
- [ ] `route_exclude_address: ["ff00::/8"]` with `auto_redirect: true` starts without EEXIST
- [ ] IPv4 `240.0.0.0/4` / `224.0.0.0/3` exclude addresses also work
- [ ] Normal non-max ranges still encode start + exclusive end

Fixes SagerNet/sing-box#4316