### PR TITLE
Expose GSO capability through LinkEndpointFilter

### DIFF
--- a/stack_gvisor_filter.go
+++ b/stack_gvisor_filter.go
@@ -111,3 +111,20 @@ func (w *networkDispatcherFilter) dispatch(protocol tcpip.NetworkProtocolNumber,
 	}
 	return w.dispatcher.Dispatch(view)
 }
+
+// The embedded interface promotes only LinkEndpoint's methods, so without
+// these the stack cannot see the wrapped endpoint's segmentation offload and
+// every TCP segment leaves at MSS size.
+func (w *LinkEndpointFilter) GSOMaxSize() uint32 {
+	if gso, ok := w.LinkEndpoint.(stack.GSOEndpoint); ok {
+		return gso.GSOMaxSize()
+	}
+	return 0
+}
+
+func (w *LinkEndpointFilter) SupportedGSO() stack.SupportedGSO {
+	if gso, ok := w.LinkEndpoint.(stack.GSOEndpoint); ok {
+		return gso.SupportedGSO()
+	}
+	return stack.GSONotSupported
+}


### PR DESCRIPTION
Expose the wrapped endpoint’s GSO capabilities through LinkEndpointFilter so gVisor can send larger TCP segments for the kernel to split. Without this, the filter hides offload support and forces gVisor to send MSS-sized segments, limiting throughput.

gVisor already checks whether its link endpoint implements stack.GSOEndpoint so this allows gVisor to pick up on the otherwise hidden interface and increase throughput.